### PR TITLE
Dev

### DIFF
--- a/User/RobotConfig/sentry.yaml
+++ b/User/RobotConfig/sentry.yaml
@@ -14,8 +14,8 @@ modules:
 - id: BMI088_0
   name: BMI088
   constructor_args:
-    gyro_freq: BMI088::GyroFreq::GYRO_400HZ_BW46HZ
-    accl_freq: BMI088::AcclFreq::ACCL_200HZ
+    gyro_freq: BMI088::GyroFreq::GYRO_1000HZ_BW116HZ
+    accl_freq: BMI088::AcclFreq::ACCL_800HZ
     gyro_range: BMI088::GyroRange::DEG_2000DPS
     accl_range: BMI088::AcclRange::ACCL_24G
     rotation:
@@ -78,14 +78,16 @@ modules:
   constructor_args:
     superpower: '@&super_power'
     is_helm: true
-    chassis_static_power_loss: 0.5
+    chassis_static_power_loss: 5.5
+    motor_count_3508: 4
+    motor_count_6020: 4
 - id: motor_yaw
-  name: RMMotor
+  name: DMMotor
   constructor_args:
     param:
-      model: RMMotor::Model::MOTOR_GM6020
-      reverse: true
-      feedback_id: 522
+      model: DMMotor::Model::MOTOR_DM4310
+      reverse: false
+      can_id: 1
       can_bus_name: can2
 - id: motor_pit
   name: RMMotor
@@ -102,7 +104,7 @@ modules:
     task_stack_depth: 2048
     pid_yaw_angle:
       k: 1.0
-      p: 20.0
+      p: 15.0
       i: 0.0
       d: 0.0
       i_limit: 0.0
@@ -110,23 +112,23 @@ modules:
       cycle: true
     pid_yaw_omega:
       k: 1.0
-      p: 2.4
+      p: 1.50
       i: 0.0
       d: 0.0
       i_limit: 0.0
       out_limit: 0.0
       cycle: false
     pid_pit_angle:
-      k: 1.0
-      p: 14.0
+      k: 1
+      p: 10.0
       i: 0.0
       d: 0.0
       i_limit: 0.0
-      out_limit: 50
+      out_limit: 0
       cycle: true
     pid_pit_omega:
       k: 1.0
-      p: 2.0
+      p: 1.0
       i: 0.0
       d: 0.0
       i_limit: 0.0
@@ -135,11 +137,13 @@ modules:
     motor_pitch: '@&motor_pit'
     motor_yaw: '@&motor_yaw'
     pit_max_angle: 4.5
-    pit_min_angle: 3.85
+    pit_min_angle: 3.82
     j_pit: 0.001
     j_yaw: 0.03
-    pit_zero: 4.16
-    yaw_zero: 1.21261156
+    pit_zero: 0.0
+    yaw_zero: 2.80775189
+    patrol_range: 5.0
+    patrol_omega: 0.01
     pit_reverse_flag: true
     thread_priority: LibXR::Thread::Priority::HIGH
 - id: motor_wheel_0
@@ -228,8 +232,8 @@ modules:
       wheel_resistance: 0.0
       error_compensation: 0.0
     pid_follow:
-      k: 0.15
-      p: 30.0
+      k: 1
+      p: 1.5
       i: 0.0
       d: 0.0
       i_limit: 0.0
@@ -260,7 +264,7 @@ modules:
       out_limit: 0.0
       cycle: true
     pid_wheel_angle_0_:
-      k: 0.0001
+      k: 0.0002
       p: 5.0
       i: 0.0
       d: 0.0
@@ -268,7 +272,7 @@ modules:
       out_limit: 0.0
       cycle: false
     pid_wheel_angle_1_:
-      k: 0.0001
+      k: 0.0002
       p: 5.0
       i: 0.0
       d: 0.0
@@ -276,16 +280,16 @@ modules:
       out_limit: 0.0
       cycle: false
     pid_wheel_angle_2_:
-      k: 0.0001
-      p: 5.0
+      k: 0.0002
+      p: 6.0
       i: 0.0
       d: 0.0
       i_limit: 0.0
       out_limit: 0.0
       cycle: false
     pid_wheel_angle_3_:
-      k: 0.0001
-      p: 5.0
+      k: 0.0002
+      p: 6.0
       i: 0.0
       d: 0.0
       i_limit: 0.0
@@ -293,32 +297,32 @@ modules:
       cycle: false
     pid_steer_angle_0_:
       k: 1.0
-      p: 10.0
-      i: 1.5
+      p: 22.0
+      i: 0.0
       d: 0.0
       i_limit: 0.0
       out_limit: 0.0
       cycle: true
     pid_steer_angle_1_:
       k: 1.0
-      p: 10.0
-      i: 1.5
+      p: 22.0
+      i: 0.0
       d: 0.0
       i_limit: 0.0
       out_limit: 0.0
       cycle: true
     pid_steer_angle_2_:
       k: 1.0
-      p: 10.0
-      i: 1.5
+      p: 22.0
+      i: 0.0
       d: 0.0
       i_limit: 0.0
       out_limit: 0.0
       cycle: true
     pid_steer_angle_3_:
       k: 1.0
-      p: 10.0
-      i: 1.5
+      p: 22.0
+      i: 0.0
       d: 0.0
       i_limit: 0.0
       out_limit: 0.0
@@ -326,7 +330,7 @@ modules:
     pid_steer_speed_0_:
       k: 1.0
       p: 0.08
-      i: 0.03
+      i: 0.0
       d: 0.0
       i_limit: 0.0
       out_limit: 0.0
@@ -334,7 +338,7 @@ modules:
     pid_steer_speed_1_:
       k: 1.0
       p: 0.08
-      i: 0.03
+      i: 0.0
       d: 0.0
       i_limit: 0.0
       out_limit: 0.0
@@ -342,7 +346,7 @@ modules:
     pid_steer_speed_2_:
       k: 1.0
       p: 0.08
-      i: 0.03
+      i: 0.0
       d: 0.0
       i_limit: 0.0
       out_limit: 0.0
@@ -350,7 +354,7 @@ modules:
     pid_steer_speed_3_:
       k: 1.0
       p: 0.08
-      i: 0.03
+      i: 0.0
       d: 0.0
       i_limit: 0.0
       out_limit: 0.0
@@ -383,29 +387,27 @@ modules:
       feedback_id: 515
       can_bus_name: can2
 - id: launcher
-  name: Launcher
+  name: InfantryLauncher
   constructor_args:
     motor_fric_front_left: '@&motor_fric_0'
     motor_fric_front_right: '@&motor_fric_1'
-    motor_fric_back_left: '@nullptr'
-    motor_fric_back_right: '@nullptr'
     motor_trig: '@&motor_trig'
     task_stack_depth: 2048
     pid_trig_angle:
       k: 1.0
-      p: 35.0
-      i: 0.0
+      p: 40.0
+      i: 0.1
       d: 0.0
       i_limit: 0.0
-      out_limit: 30.0
+      out_limit: 0.0
       cycle: false
     pid_trig_speed:
       k: 1.0
-      p: 0.65
-      i: 0.8
+      p: 0.15
+      i: 0.0005
       d: 0.0
-      i_limit: 0.0
-      out_limit: 0.5
+      i_limit: 1.0
+      out_limit: 1.0
       cycle: false
     pid_fric_speed_0:
       k: 1.0
@@ -423,32 +425,12 @@ modules:
       i_limit: 0.0
       out_limit: 1.0
       cycle: false
-    pid_fric_speed_2:
-      k: 0.0
-      p: 0.002
-      i: 0.0
-      d: 0.0
-      i_limit: 0.0
-      out_limit: 1.0
-      cycle: false
-    pid_fric_speed_3:
-      k: 0.0
-      p: 0.002
-      i: 0.0
-      d: 0.0
-      i_limit: 0.0
-      out_limit: 1.0
-      cycle: false
     launcher_param:
-      fric1_setpoint_speed: 6500.0
-      fric2_setpoint_speed: 0.0
-      trig_gear_ratio: 36.0
+      fric1_setpoint_speed: 6000.0
+      trig_gear_ratio: 36
       num_trig_tooth: 10
-      trig_freq_: 2.0
     cmd: '@&cmd'
     thread_priority: LibXR::Thread::Priority::HIGH
-  template_args:
-    LauncherType: InfantryLauncher
 - id: event_binder
   name: EventBinder
   constructor_args:
@@ -477,27 +459,19 @@ modules:
         source_event: DR16::SwitchPos::DR16_SW_R_POS_BOT
         target_module: cmd
         target_event: CMD::Mode::CMD_AUTO_CTRL
-      - source_module: dr16
-        source_event: DR16::SwitchPos::DR16_SW_L_POS_TOP
-        target_module: cmd
-        target_event: CMD::Mode::CMD_OP_CTRL
-      - source_module: dr16
-        source_event: DR16::SwitchPos::DR16_SW_L_POS_BOT
-        target_module: cmd
-        target_event: CMD::Mode::CMD_OP_CTRL
     - bindings:
       - source_module: dr16
-        source_event: DR16::SwitchPos::DR16_SW_R_POS_TOP
+        source_event: DR16::SwitchPos::DR16_SW_L_POS_TOP
         target_module: chassis
         target_event: Helm::ChassisMode::RELAX
       - source_module: dr16
-        source_event: DR16::SwitchPos::DR16_SW_R_POS_MID
-        target_module: chassis
-        target_event: Helm::ChassisMode::RELAX
-      - source_module: dr16
-        source_event: DR16::SwitchPos::DR16_SW_R_POS_BOT
+        source_event: DR16::SwitchPos::DR16_SW_L_POS_MID
         target_module: chassis
         target_event: Helm::ChassisMode::FOLLOW
+      - source_module: dr16
+        source_event: DR16::SwitchPos::DR16_SW_L_POS_BOT
+        target_module: chassis
+        target_event: Helm::ChassisMode::ROTOR
     - bindings:
       - source_module: dr16
         source_event: DR16::SwitchPos::DR16_SW_R_POS_TOP
@@ -513,9 +487,13 @@ modules:
         target_event: GimbalEvent::SET_MODE_COMMON
     - bindings:
       - source_module: dr16
+        source_event: DR16::SwitchPos::DR16_SW_L_POS_TOP
+        target_module: launcher
+        target_event: InfantryLauncher::LauncherEvent::SET_FRICMODE_RELAX
+      - source_module: dr16
         source_event: DR16::SwitchPos::DR16_SW_R_POS_TOP
         target_module: launcher
-        target_event: InfantryLauncher::LauncherEvent::SET_FRICMODE_SAFE
+        target_event: InfantryLauncher::LauncherEvent::SET_FRICMODE_RELAX
       - source_module: dr16
         source_event: DR16::SwitchPos::DR16_SW_R_POS_MID
         target_module: launcher
@@ -523,7 +501,7 @@ modules:
       - source_module: dr16
         source_event: DR16::SwitchPos::DR16_SW_R_POS_BOT
         target_module: launcher
-        target_event: InfantryLauncher::LauncherEvent::SET_FRICMODE_READY
+        target_event: InfantryLauncher::LauncherEvent::SET_FRICMODE_RELAX
 - id: hostdata
   name: HostData
   constructor_args:


### PR DESCRIPTION
@llLeo306

## Summary by Sourcery

Retune the sentry robot configuration for new hardware and control behavior, updating sensors, drivetrain, gimbal, launcher, and remote-control event bindings.

Enhancements:
- Increase IMU sampling frequencies for the BMI088 sensor.
- Adjust chassis power model and declare motor counts for 3508 and 6020 motors.
- Switch yaw actuation to a DM4310-based motor and retune gimbal PID gains, limits, and mechanical zero points, adding patrol parameters.
- Retune chassis follow, wheel, and steering PID controllers for revised motion characteristics.
- Simplify the launcher configuration to a two-friction-wheel InfantryLauncher and retune trigger and friction speed PID parameters.
- Reconfigure DR16 remote switch bindings for chassis modes and launcher friction modes, including new relax/follow/rotor mappings.