### PR TITLE
Add referee and shared topic modules to aerial.yaml

### DIFF
--- a/User/RobotConfig/aerial.yaml
+++ b/User/RobotConfig/aerial.yaml
@@ -5,3 +5,324 @@ modules:
   name: BlinkLED
   constructor_args:
     blink_cycle: 250
+- id: referee
+  name: Referee
+  constructor_args:
+    task_stack_depth: 1536
+    uart: "uart_referee"
+    baudrate: 115200
+    referee_chassis_tp_name: "chassis_ref"
+    referee_launcher_tp_name: "launcher_ref"
+    referee_sentry_tp_name: "sentry_ref"
+    thread_priority_uart: LibXR::Thread::Priority::LOW
+  required_hardware: dma uart
+- id: bmi088
+  name: BMI088
+  constructor_args:
+    gyro_freq: BMI088::GyroFreq::GYRO_1000HZ_BW116HZ
+    accl_freq: BMI088::AcclFreq::ACCL_800HZ
+    gyro_range: BMI088::GyroRange::DEG_2000DPS
+    accl_range: BMI088::AcclRange::ACCL_24G
+    rotation:
+      w: 0.0
+      x: 0.707106781187
+      y: 0.707106781187
+      z: 0.0
+    pid_param:
+      k: 0.15
+      p: 1.0
+      i: 0.1
+      d: 0.0
+      i_limit: 0.3
+      out_limit: 1.0
+      cycle: false
+    gyro_topic_name: bmi088_gyro
+    accl_topic_name: bmi088_accl
+    target_temperature: 45
+    task_stack_depth: 2048
+    camera_sync_pin_name: CAMERA
+    camera_sync_div: 10
+- id: ahrs
+  name: MadgwickAHRS
+  constructor_args:
+    beta: 0.033
+    gyro_topic_name: bmi088_gyro
+    accl_topic_name: bmi088_accl
+    quaternion_topic_name: ahrs_quaternion
+    euler_topic_name: ahrs_euler
+    task_stack_depth: 2048
+- id: buzzer_alarm
+  name: BuzzerAlarm
+  constructor_args:
+    alarm_freq: 5000
+    alarm_duty: 300
+    alarm_cycle: 300
+- id: cmd
+  name: CMD
+  constructor_args:
+    mode: CMD::Mode::CMD_OP_CTRL
+    chassis_cmd_topic_name: chassis_cmd
+    gimbal_cmd_topic_name: gimbal_cmd
+    launcher_cmd_topic_name: launcher_cmd
+- id: hostdata
+  name: HostData
+  constructor_args:
+    cmd: '@cmd'
+    host_euler_topic_name: target_euler
+    host_chassis_data_topic_name: chassis_data
+    host_fire_topic_name: fire_notify
+- id: dr16
+  name: DR16
+  constructor_args:
+    CMD: '@cmd'
+    task_stack_depth_uart: 1536
+- id: motor_fric_0
+  name: RMMotor
+  constructor_args:
+    param:
+      model: RMMotor::Model::MOTOR_M3508
+      reverse: true
+      feedback_id: 0x201
+      can_bus_name: can1
+- id: motor_fric_1
+  name: RMMotor
+  constructor_args:
+    param:
+      model: RMMotor::Model::MOTOR_M3508
+      reverse: false
+      feedback_id: 0x203
+      can_bus_name: can1
+- id: motor_trig
+  name: RMMotor
+  constructor_args:
+    param:
+      model: RMMotor::Model::MOTOR_M2006
+      reverse: false
+      feedback_id: 0x202
+      can_bus_name: can1
+- id: motor_pit
+  name: RMMotor
+  constructor_args:
+    param:
+      model: RMMotor::Model::MOTOR_GM6020
+      reverse: false
+      feedback_id: 0x208
+      can_bus_name: can1
+- id: motor_yaw
+  name: RMMotor
+  constructor_args:
+    param:
+      model: RMMotor::Model::MOTOR_GM6020
+      reverse: true
+      feedback_id: 0x20A
+      can_bus_name: can1
+- id: gimbal
+  name: Gimbal
+  constructor_args:
+    motor_pit: '@&motor_pit'
+    motor_yaw: '@&motor_yaw'
+    cmd: '@cmd'
+    referee: '@nullptr'
+    task_stack_depth: 2048
+    GimbalParam:
+      max_pitch_angle_: 1.68
+      min_pitch_angle_: 0.92
+      max_yaw_angle_: 0.0
+      min_yaw_angle_: 0.0
+      pitch_reverse_: true
+      yaw_reverse_: true
+      pit_inertia_: 0.0218
+      yaw_inertia_: 0.02183
+      pit_dpi_: 1.7
+      yaw_dpi_: 1.7
+    pid_pitch_angle_param:
+      k: 1.0
+      p: 30.0
+      i: 0.0
+      d: 0.0
+      i_limit: 0.0
+      out_limit: 0.0
+      cycle: true
+    pid_pitch_omega_param:
+      k: 1.0
+      p: 1.0
+      i: 0.0
+      d: 0.0
+      i_limit: 0.22
+      out_limit: 2.2
+      cycle: false
+    pid_yaw_angle_param:
+      k: 1.0
+      p: 30.0
+      i: 0.0
+      d: 0.0
+      i_limit: 0.0
+      out_limit: 0.0
+      cycle: true
+    pid_yaw_omega_param:
+      k: 1.0
+      p: 1.1
+      i: 0.0
+      d: 0.0
+      i_limit: 0.0
+      out_limit: 2.2
+      cycle: false
+  template_args:
+    Motor
+- id: launcher
+  name: Launcher
+  constructor_args:
+    motor_fric_0: '@&motor_fric_0'
+    motor_fric_1: '@&motor_fric_1'
+    motor_fric_2: '@nullptr'
+    motor_fric_3: '@nullptr'
+    motor_trig: '@&motor_trig'
+    task_stack_depth: 4096
+    pid_trig_angle:
+      k: 1.0
+      p: 35.0
+      i: 0.0
+      d: 0.0
+      i_limit: 0.0
+      out_limit: 0.0
+      cycle: false
+    pid_trig_speed:
+      k: 1.0
+      p: 0.65
+      i: 0.8
+      d: 0.0
+      i_limit: 0.0
+      out_limit: 0.5
+      cycle: false
+    pid_fric_0:
+      k: 1.0
+      p: 0.002
+      i: 0.0
+      d: 0.0
+      i_limit: 0.0
+      out_limit: 1.0
+      cycle: false
+    pid_fric_1:
+      k: 1.0
+      p: 0.002
+      i: 0.0
+      d: 0.0
+      i_limit: 0.0
+      out_limit: 1.0
+      cycle: false
+    pid_fric_2:
+      k: 0.0
+      p: 0.002
+      i: 0.0
+      d: 0.0
+      i_limit: 0.0
+      out_limit: 1.0
+      cycle: false
+    pid_fric_3:
+      k: 0.0
+      p: 0.002
+      i: 0.0
+      d: 0.0
+      i_limit: 0.0
+      out_limit: 1.0
+      cycle: false
+    launcher_param:
+      fric1_setpoint_speed: 7200.0
+      fric2_setpoint_speed: 0.0
+      trig_gear_ratio: 36.0
+      num_trig_tooth: 10
+      expect_trig_freq_: 20.0
+    cmd: '@&cmd'
+  template_args:
+    InfantryLauncher
+- id: sharedtopic
+  name: SharedTopic
+  constructor_args:
+    uart_name: usb_otg_hs_cdc
+    task_stack_depth: 2048
+    buffer_size: 256
+    topic_configs:
+    - fire_notify
+    - target_euler
+    - chassis_data
+- id: sharedtopicclient
+  name: SharedTopicClient
+  constructor_args:
+    uart_name: usb_otg_hs_cdc
+    task_stack_depth: 2048
+    buffer_size: 256
+    topic_configs:
+    - ahrs_quaternion
+- id: event_binder
+  name: EventBinder
+  constructor_args:
+    modules:
+    - name: dr16
+      module_ref: '@dr16'
+    - name: cmd
+      module_ref: '@cmd'
+    - name: gimbal
+      module_ref: '@gimbal'
+    - name: launcher
+      module_ref: '@launcher'
+    event_binding_groups:
+    - bindings:
+      - source_module: dr16
+        source_event: DR16::SwitchPos::DR16_SW_L_POS_MID
+        target_module: cmd
+        target_event: CMD::Mode::CMD_OP_CTRL
+      - source_module: dr16
+        source_event: DR16::SwitchPos::DR16_SW_L_POS_BOT
+        target_module: cmd
+        target_event: CMD::Mode::CMD_AUTO_CTRL
+      - source_module: dr16
+        source_event: DR16::SwitchPos::DR16_SW_R_POS_MID
+        target_module: cmd
+        target_event: CMD::Mode::CMD_OP_CTRL
+      - source_module: dr16
+        source_event: DR16::SwitchPos::DR16_SW_R_POS_BOT
+        target_module: cmd
+        target_event: CMD::Mode::CMD_AUTO_CTRL
+    - bindings:
+      - source_module: dr16
+        source_event: DR16::Key::KEY_L_PRESS
+        target_module: cmd
+        target_event: CMD::Mode::CMD_OP_CTRL
+      - source_module: dr16
+        source_event: DR16::Key::KEY_L_RELEASE
+        target_module: cmd
+        target_event: CMD::Mode::CMD_OP_CTRL
+      - source_module: dr16
+        source_event: DR16::Key::KEY_R_PRESS
+        target_module: cmd
+        target_event: CMD::Mode::CMD_AUTO_CTRL
+      - source_module: dr16
+        source_event: DR16::Key::KEY_R_RELEASE
+        target_module: cmd
+        target_event: CMD::Mode::CMD_OP_CTRL
+    - bindings:
+      - source_module: dr16
+        source_event: DR16::SwitchPos::DR16_SW_R_POS_TOP
+        target_module: gimbal
+        target_event: GimbalMode::RELAX
+      - source_module: dr16
+        source_event: DR16::SwitchPos::DR16_SW_R_POS_MID
+        target_module: gimbal
+        target_event: GimbalMode::AUTOAIM
+      - source_module: dr16
+        source_event: DR16::SwitchPos::DR16_SW_R_POS_BOT
+        target_module: gimbal
+        target_event: GimbalMode::AUTOAIM
+    - bindings:
+      - source_module: dr16
+        source_event: DR16::SwitchPos::DR16_SW_L_POS_TOP
+        target_module: launcher
+        target_event: InfantryLauncher::LauncherEvent::SET_FRICMODE_SAFE
+      - source_module: dr16
+        source_event: DR16::SwitchPos::DR16_SW_L_POS_MID
+        target_module: launcher
+        target_event: InfantryLauncher::LauncherEvent::SET_FRICMODE_READY
+      - source_module: dr16
+        source_event: DR16::SwitchPos::DR16_SW_L_POS_BOT
+        target_module: launcher
+        target_event: InfantryLauncher::LauncherEvent::SET_FRICMODE_READY


### PR DESCRIPTION
The code of aerial.yml has been completed.

## Summary by Sourcery

Configure the aerial robot with full module definitions for sensors, control, gimbal, launcher, shared topics, and event bindings.

New Features:
- Add referee, IMU (BMI088), AHRS, buzzer alarm, and command/host data modules to the aerial robot configuration.
- Add motor, gimbal, and launcher modules for chassis actuation and firing control in the aerial configuration.
- Introduce shared topic and shared topic client modules for USB-based topic synchronization.
- Define an event binder module wiring DR16 controller inputs to command, gimbal, and launcher mode events.

Enhancements:
- Extend aerial.yaml with task stack, PID, and parameter settings for all newly added modules to support runtime tuning via configuration.