### PR TITLE
fix(app): remove unused bootstrap topic

### DIFF
--- a/User/app_main.cpp
+++ b/User/app_main.cpp
@@ -74,9 +74,6 @@ extern "C" void app_main(void) {
   // clang-format on
   // NOLINTEND
   /* User Code Begin 2 */
-  auto topic_bootstrap = LibXR::Topic::CreateTopic<uint8_t>(
-      "__libxr_bootstrap", nullptr, false, false, true);
-  UNUSED(topic_bootstrap);
   /* User Code End 2 */
   // clang-format off
   // NOLINTBEGIN


### PR DESCRIPTION
## Summary
- remove the unused `__libxr_bootstrap` topic creation from `User/app_main.cpp`
- keep the CubeMX user-code markers intact

## Validation
- Docker CI-equivalent STM32 build for `User/RobotConfig/sentry.yaml` passed in `ghcr.io/xrobot-org/docker-image-stm32:main`
- log: `/tmp/bsp_dev_c_bootstrap_validate_20260630/sentry_build.log` on Ubuntu24

## Summary by Sourcery

Enhancements:
- Clean up app_main by removing an unused LibXR bootstrap topic while preserving CubeMX user-code markers.